### PR TITLE
Fixed block naming

### DIFF
--- a/app/templates/src/twig/layout/_layout.twig
+++ b/app/templates/src/twig/layout/_layout.twig
@@ -6,7 +6,7 @@
 </head>
 <body>
 <section>
-    {% block page %}{% endblock %}
+    {% block content %}{% endblock %}
 </section>
 {% include '../parts/site-scripts.twig' %}
 </body>


### PR DESCRIPTION
Content would not be displayed in initial template if block has the name page.